### PR TITLE
Remove xdotool for wayland

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This separation ensures the extension follows GNOME's best practices and securit
 - GNOME Shell 46 or later
 - Python 3.8 or later
 - FFmpeg (for audio recording)
-- xdotool (for text insertion)
+- xdotool (for text insertion on X11 only)
 - Clipboard tool: xclip/xsel (X11) or wl-clipboard (Wayland)
 
 ### Installation of System Dependencies
@@ -64,7 +64,7 @@ sudo apt install python3 python3-pip python3-venv ffmpeg xdotool xclip
 
 # For Wayland sessions
 sudo apt update
-sudo apt install python3 python3-pip python3-venv ffmpeg xdotool wl-clipboard
+sudo apt install python3 python3-pip python3-venv ffmpeg wl-clipboard
 ```
 
 **Note:** This extension has been tested extensively on Ubuntu 24.04 / GNOME 46 / X11+Wayland. It should work on other GNOME Shell 46+ distributions with the above packages installed, but hasn't been tested on other platforms yet.

--- a/install.sh
+++ b/install.sh
@@ -185,12 +185,16 @@ check_system_deps() {
         missing_deps+=("ffmpeg")
     fi
     
-    # Check xdotool (for text insertion on X11)
-    if command_exists xdotool; then
-        print_status "xdotool found (text insertion support)"
+    # Check xdotool (for text insertion on X11 only)
+    if [ "${XDG_SESSION_TYPE:-}" != "wayland" ]; then
+        if command_exists xdotool; then
+            print_status "xdotool found (text insertion support)"
+        else
+            print_warning "xdotool not found (text insertion on X11 will not work)"
+            missing_deps+=("xdotool")
+        fi
     else
-        print_warning "xdotool not found (text insertion on X11 will not work)"
-        missing_deps+=("xdotool")
+        print_status "Skipping xdotool check (not needed for Wayland sessions)"
     fi
     
     # Check clipboard tools (session-type specific)

--- a/speech2text-service/README.md
+++ b/speech2text-service/README.md
@@ -66,9 +66,11 @@ To modify the service:
 
 ### Text insertion fails
 
-1. Ensure xdotool is installed: `xdotool version`
-2. Test manually: `xdotool type "test"`
-3. Check if running on X11 or Wayland
+1. Check if running on X11 or Wayland: `echo $XDG_SESSION_TYPE`
+2. For X11 sessions:
+   - Ensure xdotool is installed: `xdotool version`
+   - Test manually: `xdotool type "test"`
+3. For Wayland sessions: Text insertion may have limitations (xdotool not required)
 
 ### Dependencies missing
 

--- a/speech2text-service/install.sh
+++ b/speech2text-service/install.sh
@@ -55,9 +55,9 @@ echo ""
 echo -e "${BLUE}This script will install all required dependencies for Ubuntu.${NC}"
 echo ""
 if [ "${XDG_SESSION_TYPE:-}" = "wayland" ]; then
-    echo "Required packages: python3, python3-pip, python3-venv, python3-dbus, python3-gi, ffmpeg, xdotool, wl-clipboard"
+    echo "Required packages: python3, python3-pip, python3-venv, python3-dbus, python3-gi, ffmpeg, wl-clipboard"
     echo "We need to run the following command to install all dependencies:"
-    echo "sudo apt update && sudo apt install -y python3 python3-pip python3-venv python3-dbus python3-gi ffmpeg xdotool wl-clipboard"
+    echo "sudo apt update && sudo apt install -y python3 python3-pip python3-venv python3-dbus python3-gi ffmpeg wl-clipboard"
 else
     echo "Required packages: python3, python3-pip, python3-venv, python3-dbus, python3-gi, ffmpeg, xdotool, xclip"
     echo "We need to run the following command to install all dependencies:"
@@ -72,7 +72,7 @@ case "$install_all" in
     * ) 
         print_status "Installing all dependencies..."
         if [ "${XDG_SESSION_TYPE:-}" = "wayland" ]; then
-            sudo apt update && sudo apt install -y python3 python3-pip python3-venv python3-dbus python3-gi ffmpeg xdotool wl-clipboard
+            sudo apt update && sudo apt install -y python3 python3-pip python3-venv python3-dbus python3-gi ffmpeg wl-clipboard
         else
             sudo apt update && sudo apt install -y python3 python3-pip python3-venv python3-dbus python3-gi ffmpeg xdotool xclip
         fi
@@ -157,22 +157,26 @@ if ! command_exists ffmpeg; then
     esac
 fi
 
-# Check for xdotool
-if ! command_exists xdotool; then
-    echo -e "${RED}Error:${NC} xdotool is not installed."
-    echo ""
-    echo "Please run the following command to install it:"
-    echo -e "${YELLOW}sudo apt update && sudo apt install -y xdotool${NC}"
-    echo ""
-    install_xdotool=$(ask_user "Would you like to run this command now? [y/N]: " "y")
-    case "$install_xdotool" in
-        [Yy]* ) 
-            sudo apt update && sudo apt install -y xdotool || error_exit "Failed to install xdotool"
-            ;;
-        * ) 
-            error_exit "xdotool is required. Please install it and run this script again."
-            ;;
-    esac
+# Check for xdotool (only required for X11 sessions)
+if [ "${XDG_SESSION_TYPE:-}" != "wayland" ]; then
+    if ! command_exists xdotool; then
+        echo -e "${RED}Error:${NC} xdotool is not installed."
+        echo ""
+        echo "Please run the following command to install it:"
+        echo -e "${YELLOW}sudo apt update && sudo apt install -y xdotool${NC}"
+        echo ""
+        install_xdotool=$(ask_user "Would you like to run this command now? [y/N]: " "y")
+        case "$install_xdotool" in
+            [Yy]* ) 
+                sudo apt update && sudo apt install -y xdotool || error_exit "Failed to install xdotool"
+                ;;
+            * ) 
+                error_exit "xdotool is required for X11 sessions. Please install it and run this script again."
+                ;;
+        esac
+    fi
+else
+    print_status "Skipping xdotool check (not needed for Wayland sessions)"
 fi
 
 # Check for clipboard tools (session-type specific)

--- a/speech2text-service/speech2text_service.py
+++ b/speech2text-service/speech2text_service.py
@@ -58,11 +58,12 @@ class Speech2TextService(dbus.service.Object):
         except (FileNotFoundError, subprocess.CalledProcessError):
             missing.append("ffmpeg")
         
-        # Check for xdotool (for X11 typing)
-        try:
-            subprocess.run(['xdotool', '--version'], capture_output=True, check=True)
-        except (FileNotFoundError, subprocess.CalledProcessError):
-            missing.append("xdotool")
+        # Check for xdotool (for X11 typing only)
+        if session_type != 'wayland':
+            try:
+                subprocess.run(['xdotool', '--version'], capture_output=True, check=True)
+            except (FileNotFoundError, subprocess.CalledProcessError):
+                missing.append("xdotool")
         
         # Check for clipboard tools (session-type specific)
         clipboard_available = False


### PR DESCRIPTION
Remove xdotool as a Wayland dependency because it is an X11-specific tool.

---
<a href="https://cursor.com/background-agent?bcId=bc-531791fa-98af-40fd-9fb1-7e4b097f9f50">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-531791fa-98af-40fd-9fb1-7e4b097f9f50">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>