### PR TITLE
fix: support GNOME 50 (Meta.is_wayland_compositor removed in Mutter 18)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Speech2Text Extension - Makefile
 # Automates common development and installation tasks
 
-EXTENSION_UUID = speech2text-extension@kaveh.page
+EXTENSION_UUID = gnome-speech2text@kaveh.page
 EXTENSION_DIR = $(HOME)/.local/share/gnome-shell/extensions/$(EXTENSION_UUID)
 SOURCE_DIR = src
 SCHEMAS_DIR = $(EXTENSION_DIR)/schemas

--- a/src/lib/recordingDialog.js
+++ b/src/lib/recordingDialog.js
@@ -1,6 +1,5 @@
 import Clutter from "gi://Clutter";
 import GLib from "gi://GLib";
-import Meta from "gi://Meta";
 import St from "gi://St";
 import * as Main from "resource:///org/gnome/shell/ui/main.js";
 import * as Config from "resource:///org/gnome/shell/misc/config.js";
@@ -11,6 +10,7 @@ import {
   cleanupChromeWidget,
   cleanupRecordingModal,
   centerWidgetOnMonitor,
+  isWaylandCompositor,
   log,
 } from "./resourceUtils.js";
 
@@ -363,7 +363,7 @@ export class RecordingDialog {
     log.debug(`Showing preview with text: "${text}"`);
 
     // Check if we're on Wayland
-    const isWayland = Meta.is_wayland_compositor();
+    const isWayland = isWaylandCompositor();
 
     // Update UI for preview mode - change icon and label
     if (this.recordingIcon) {
@@ -651,7 +651,7 @@ export class RecordingDialog {
               }
 
               // Only try global.stage.set_key_focus on X11 or as fallback
-              const isWayland = Meta.is_wayland_compositor();
+              const isWayland = isWaylandCompositor();
               if (!isWayland && global.stage?.set_key_focus) {
                 global.stage.set_key_focus(this.modalBarrier);
                 log.debug("Focus set using global.stage.set_key_focus");

--- a/src/lib/recordingStateManager.js
+++ b/src/lib/recordingStateManager.js
@@ -1,7 +1,10 @@
-import Meta from "gi://Meta";
 import * as Main from "resource:///org/gnome/shell/ui/main.js";
 import { COLORS } from "./constants.js";
-import { log, readInstalledServiceConfig } from "./resourceUtils.js";
+import {
+  log,
+  readInstalledServiceConfig,
+  isWaylandCompositor,
+} from "./resourceUtils.js";
 
 export class RecordingStateManager {
   constructor(icon, dbusManager) {
@@ -235,7 +238,7 @@ export class RecordingStateManager {
 
     // Check if we should skip preview and auto-insert
     const skipPreviewX11 = settings.get_boolean("skip-preview-x11");
-    const isWayland = Meta.is_wayland_compositor();
+    const isWayland = isWaylandCompositor();
 
     log.debug(`=== SETTINGS CHECK ===`);
     log.debug(`skipPreviewX11 (auto-insert): ${skipPreviewX11}`);

--- a/src/lib/resourceUtils.js
+++ b/src/lib/resourceUtils.js
@@ -2,6 +2,7 @@ import * as Main from "resource:///org/gnome/shell/ui/main.js";
 import Clutter from "gi://Clutter";
 import Gio from "gi://Gio";
 import GLib from "gi://GLib";
+import Meta from "gi://Meta";
 
 let _debugEnabled = null;
 export function isDebugEnabled() {
@@ -22,6 +23,31 @@ export const log = {
   warn: (...args) => console.warn(...args),
   error: (...args) => console.error(...args),
 };
+
+/**
+ * Detect whether the shell is running as a Wayland compositor.
+ *
+ * Meta.is_wayland_compositor() was removed in GNOME 50 / Mutter 18, so calling
+ * it directly throws "is_wayland_compositor is not a function" and takes down
+ * any dialog that touches it (recording dialog, settings dialog, hover buttons).
+ * Prefer the Meta API when it still exists (older GNOME), and fall back to the
+ * session environment, which is reliable inside the gnome-shell process.
+ *
+ * @returns {boolean} true if running on Wayland
+ */
+export function isWaylandCompositor() {
+  try {
+    if (typeof Meta.is_wayland_compositor === "function") {
+      return Meta.is_wayland_compositor();
+    }
+  } catch (_e) {
+    // Fall through to environment-based detection.
+  }
+
+  const sessionType = (GLib.getenv("XDG_SESSION_TYPE") || "").toLowerCase();
+  if (sessionType) return sessionType === "wayland";
+  return !!GLib.getenv("WAYLAND_DISPLAY");
+}
 
 /**
  * Read the installed service configuration from install-state.conf.

--- a/src/lib/settingsDialog.js
+++ b/src/lib/settingsDialog.js
@@ -1,7 +1,6 @@
 import Clutter from "gi://Clutter";
 import GLib from "gi://GLib";
 import St from "gi://St";
-import Meta from "gi://Meta";
 import * as Main from "resource:///org/gnome/shell/ui/main.js";
 
 import { COLORS, STYLES, createAccentDisplayStyle } from "./constants.js";
@@ -23,6 +22,7 @@ import {
   showModalDialog,
   closeModalDialog,
   setupModalEventHandlers,
+  isWaylandCompositor,
 } from "./resourceUtils.js";
 
 export class SettingsDialog {
@@ -290,7 +290,7 @@ export class SettingsDialog {
     }
 
     // 3) auto-insert (X11 only)
-    if (!Meta.is_wayland_compositor()) {
+    if (!isWaylandCompositor()) {
       const row = createHorizontalBox("12px", "0px");
       const label = createStyledLabel(
         "Auto-insert mode at cursor (x11 only)",

--- a/src/lib/uiUtils.js
+++ b/src/lib/uiUtils.js
@@ -2,7 +2,7 @@ import Meta from "gi://Meta";
 import St from "gi://St";
 import * as Config from "resource:///org/gnome/shell/misc/config.js";
 import { COLORS, STYLES } from "./constants.js";
-import { log } from "./resourceUtils.js";
+import { log, isWaylandCompositor } from "./resourceUtils.js";
 
 // Helper function to create button styles
 export function createButtonStyle(baseColor, hoverColor) {
@@ -32,7 +32,7 @@ export function addHandCursorToButton(button) {
     }
   })();
 
-  const isWayland = Meta.is_wayland_compositor();
+  const isWayland = isWaylandCompositor();
 
   // Disable cursor changes on GNOME 48+ Wayland due to crashes
   if (isGNOME48Plus && isWayland) {


### PR DESCRIPTION
Meta.is_wayland_compositor() was removed from the introspected API in GNOME 50 / Mutter 18, so every call threw "is_wayland_compositor is not a function". This broke the recording dialog and settings dialog (they failed while building hover buttons via createHoverButton), so pressing the shortcut started recording in the service but never showed any UI, and the settings window did not open. The setup dialog still worked because it is the only one not using createHoverButton.

Add an isWaylandCompositor() helper in resourceUtils that uses the Meta API when available (older GNOME) and falls back to XDG_SESSION_TYPE / WAYLAND_DISPLAY, then route all 5 call sites through it.

Also fix EXTENSION_UUID in the Makefile (was the stale speech2text-extension@kaveh.page, actual UUID is
gnome-speech2text@kaveh.page)
so `make install` deploys to the directory the shell actually loads.